### PR TITLE
feat: implement backup functionality before stow operations (issue #17)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,8 +28,7 @@ sudo chmod u+x macos/install.sh
 ./macos/install.sh --email "your@email.com" --name "Your Name"
 
 # Options:
-./macos/install.sh --backup     # Backup existing files (default)
-./macos/install.sh --no-backup  # Skip backup of existing files
+./macos/install.sh --no-backup  # Skip backup of existing files (backup is default)
 ```
 
 ### Package Management Commands

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,8 +28,8 @@ sudo chmod u+x macos/install.sh
 ./macos/install.sh --email "your@email.com" --name "Your Name"
 
 # Options:
-./macos/install.sh --link    # Create symlinks (default)
-./macos/install.sh --copy    # Copy files instead
+./macos/install.sh --backup     # Backup existing files (default)
+./macos/install.sh --no-backup  # Skip backup of existing files
 ```
 
 ### Package Management Commands
@@ -64,7 +64,7 @@ bash macos/scripts/macos.sh
 4. **Terminal Enhancement**: Custom colors, tmux integration, vi-mode support
 
 ### Configuration Management
-Files are installed via symlinks (default) or copying using GNU Stow:
+Files are installed via symlinks using GNU Stow:
 - Dotfiles in `macos/home/` are stowed to `$HOME/`
 - Neovim config goes to `$HOME/.config/nvim/`
 - Bat config goes to `$HOME/.config/bat/`

--- a/macos/install.sh
+++ b/macos/install.sh
@@ -85,6 +85,11 @@ done
 # Get the current working directory.
 PWD=$(pwd)
 
+# Validate stow is available
+if ! command -v stow >/dev/null 2>&1; then
+    die "ERROR: GNU Stow is required but not installed"
+fi
+
 # Function to backup existing files before stow operations
 backup_existing_files() {
     if [[ $backup == 0 ]]; then
@@ -162,7 +167,7 @@ backup_existing_files() {
                 ((files_backed_up++))
             else
                 echo "  ✗ $relative_path (copy failed)" >> "$manifest_file"
-                die "ERROR: Failed to backup $relative_path"
+                die "ERROR: Failed to backup $relative_path - check permissions for $(dirname "$backup_file")"
             fi
         else
             die "ERROR: Conflict file $relative_path doesn't exist at target"

--- a/macos/install.sh
+++ b/macos/install.sh
@@ -14,9 +14,8 @@ name=
 
 # TODO: Add a verbose option.
 show_help() {
-    echo "Usage: ./install.sh [-h | --help] [--backup | --no-backup] [-e | --email] [-n | --name]"
+    echo "Usage: ./install.sh [-h | --help] [--no-backup] [-e | --email] [-n | --name]"
     echo "       -h, --help     | Show this help."
-    echo "       --backup       | Backup existing files before stow operations (default)."
     echo "       --no-backup    | Skip backing up existing files before stow operations."
     echo "       -e, --email    | The email that you would like to use for setting up things like git, ssh e.g. \"abc@example.com\"."
     echo "       -n, --name     | The name that you would like to use for setting up things like git e.g. \"John Doe\"."
@@ -30,10 +29,6 @@ while :; do
     -h | -\? | --help)
         show_help
         exit
-        ;;
-    --backup)
-        backup=1
-        shift
         ;;
     --no-backup)
         backup=0


### PR DESCRIPTION
## Summary
Implements backup functionality before stow operations to prevent data loss during dotfiles installation.

## Changes
- Add `--no-backup` CLI flag (backup enabled by default)
- Implement `backup_existing_files()` function using stow simulation mode
- Create timestamped backup directories with preserved structure
- Integration with stow symlink operations
- Error handling for disk space and permissions
- User feedback about backup location and contents

## Test plan
- [x] Test backup with existing dotfiles that would conflict
- [x] Verify stow symlink operations work correctly after backup
- [x] Test --no-backup flag functionality
- [x] Verify backup preserves file permissions and directory structure

## Fixes
Closes #17